### PR TITLE
Hash trees, callback, others

### DIFF
--- a/UnitTest/TestmlBaseLoader.pas
+++ b/UnitTest/TestmlBaseLoader.pas
@@ -20,7 +20,7 @@ type
     fEventCalled: Boolean;
     procedure LoadHelper(aPath: String);
     procedure TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream: TStream; var
-        aFreeStream: Boolean);
+        aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
   public
     procedure SetUp; override;
     procedure TearDown; override;
@@ -224,7 +224,7 @@ begin
 end;
 
 procedure TestTMlBaseLoader.TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream:
-    TStream; var aFreeStream: Boolean);
+    TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 begin
   fEventCalled := true;
 end;

--- a/UnitTest/TestmlLibraryManager.pas
+++ b/UnitTest/TestmlLibraryManager.pas
@@ -17,9 +17,9 @@ type
     fMemStream: TMemoryStream;
     fEventCalled: Boolean;
     procedure TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream: TStream; var
-        aFreeStream: Boolean);
+        aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
     procedure TestEventLoadActionFromMem(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream:
-        TStream; var aFreeStream: Boolean);
+        TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
   public
     procedure SetUp; override;
     procedure TearDown; override;
@@ -50,13 +50,13 @@ type
 implementation
 
 procedure TestLibraryManager.TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var
-    aStream: TStream; var aFreeStream: Boolean);
+    aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 begin
   fEventCalled := true;
 end;
 
 procedure TestLibraryManager.TestEventLoadActionFromMem(const aLibName, aDependentLib: String; var aLoadAction:
-    TLoadAction; var aStream: TStream; var aFreeStream: Boolean);
+    TLoadAction; var aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 var
   SourceFile: String;
 begin

--- a/UnitTest/TestmlLibraryManagerHooked.pas
+++ b/UnitTest/TestmlLibraryManagerHooked.pas
@@ -17,9 +17,9 @@ type
     fMemStream: TMemoryStream;
     fEventCalled: Boolean;
     procedure TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream: TStream; var
-        aFreeStream: Boolean);
+        aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
     procedure TestEventLoadActionFromMem(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream:
-        TStream; var aFreeStream: Boolean);
+        TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
   public
     procedure SetUp; override;
     procedure TearDown; override;
@@ -49,13 +49,13 @@ type
 implementation
 
 procedure TestLibraryManagerHooked.TestEvent(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var
-    aStream: TStream; var aFreeStream: Boolean);
+    aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 begin
   fEventCalled := true;
 end;
 
 procedure TestLibraryManagerHooked.TestEventLoadActionFromMem(const aLibName, aDependentLib: String; var aLoadAction:
-    TLoadAction; var aStream: TStream; var aFreeStream: Boolean);
+    TLoadAction; var aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 var
   SourceFile: String;
 begin

--- a/mlBPLLoader.pas
+++ b/mlBPLLoader.pas
@@ -24,6 +24,7 @@ uses
   SysUtils,
   SysConst,
   Classes,
+  HashTrie,
   mlBaseLoader,
   mlTypes;
 
@@ -83,7 +84,9 @@ type
     constructor Create; overload;
     constructor Create(aMem: TStream; const aLibFileName: String; aValidatePackage: TValidatePackageProc = nil); overload;
     destructor Destroy; override;
-    procedure LoadFromStream(aMem: TStream; const aLibFileName: String; aValidatePackage: TValidatePackageProc = nil);
+    procedure LoadFromStream(aMem: TStream; const aLibFileName: String;
+        aValidatePackage: TValidatePackageProc = nil; aHandleHash: TIntegerHashTrie
+        = nil; aNamesHash: TStringHashTrie = nil);
     procedure Unload; overload;
   end;
 
@@ -398,8 +401,9 @@ begin
   end;
 end;
 
-procedure TBPLLoader.LoadFromStream(aMem: TStream; const aLibFileName: String; aValidatePackage: TValidatePackageProc =
-    nil);
+procedure TBPLLoader.LoadFromStream(aMem: TStream; const aLibFileName: String;
+    aValidatePackage: TValidatePackageProc = nil; aHandleHash: TIntegerHashTrie
+    = nil; aNamesHash: TStringHashTrie = nil);
 begin
   if aLibFileName = '' then
     raise EMlLibraryLoadError.Create('The package file name can not be empty');
@@ -408,7 +412,7 @@ begin
     raise EMlLibraryLoadError.CreateFmt('The %s package is already loaded from disk with the regular LoadPackage.' + #13#10 +
       ' Loading it again from memory will result in unpredicted behaviour.', [aLibFileName]);
 
-  inherited LoadFromStream(aMem, aLibFileName);
+  inherited LoadFromStream(aMem, aLibFileName, aHandleHash, aNamesHash);
   try
     Assert(Handle <> 0, 'The Handle of a package must be assigned before loading it from a stream. It is used in RegisterModule');
     InitializePackage(Cardinal(Handle), aValidatePackage);

--- a/mlManagers.pas
+++ b/mlManagers.pas
@@ -41,8 +41,8 @@ type
     fHandleHash      : TIntegerHashTrie;
     fNamesHash       : TStringHashTrie;
     fOnDependencyLoad: TMlLoadDependentLibraryEvent;
-    procedure DoDependencyLoad(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream:
-        TStream; var aFreeStream: Boolean);
+    procedure DoDependencyLoad(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var aStream: TStream;
+        var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
   public
     constructor Create;
     destructor Destroy; override;
@@ -117,10 +117,10 @@ implementation
 
 /// This method is assigned to each TmlBaseLoader and forwards the event to the global MlOnDependencyLoad procedure if one is assigned
 procedure TMlLibraryManager.DoDependencyLoad(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var
-    aStream: TStream; var aFreeStream: Boolean);
+    aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle);
 begin
   if Assigned(fOnDependencyLoad) then
-    fOnDependencyLoad(aLibName, aDependentLib, aLoadAction, aStream, aFreeStream);
+    fOnDependencyLoad(aLibName, aDependentLib, aLoadAction, aStream, aFreeStream, aLoadedHandle);
 end;
 
 constructor TMlLibraryManager.Create;
@@ -211,11 +211,9 @@ begin
       // Or load the library if it is a new one
       Loader := TMlBaseLoader.Create;
       try
-        fLibs.Add(Loader); // It is added to the list first because loading checks its own handle (in LoadPackageMl)
+        fLibs.Add(Loader);
         Loader.OnDependencyLoad := DoDependencyLoad;
-        Loader.LoadFromStream(aStream, aLibFileName);
-        fHandleHash.Add(Loader.Handle, TObject(Loader));
-        fNamesHash.Add(aLibFileName, TObject(Loader));
+        Loader.LoadFromStream(aStream, aLibFileName, fHandleHash, fNamesHash);
         Result := Loader.Handle;
       except on E: Exception do
         begin
@@ -349,11 +347,9 @@ begin
       // Or load the library if it is a new one
       Loader := TBPLLoader.Create;
       try
-        fLibs.Add(Loader); // It is added to the list first because loading checks its own handle (in LoadPackageMl)
+        fLibs.Add(Loader);
         Loader.OnDependencyLoad := DoDependencyLoad;
-        Loader.LoadFromStream(aStream, aLibFileName, aValidatePackage);
-        fHandleHash.Add(Loader.Handle, TObject(Loader));
-        fNamesHash.Add(aLibFileName, TObject(Loader));
+        Loader.LoadFromStream(aStream, aLibFileName, aValidatePackage, fHandleHash, fNamesHash);
         Result := Loader.Handle;
       except on E: Exception do
         begin

--- a/mlTypes.pas
+++ b/mlTypes.pas
@@ -29,11 +29,13 @@ type
   ///   laDiscard - don't load the library
   ///   laHardDrive - load the library with the standard LoadLibrary Windows API
   ///   laStream - load the library from the stream passed in aStream (which has to be freed later)
-  TLoadAction = (laHardDisk, laStream, laDiscard);
+  ///   laLoaded - the library is loaded by the callback and the handle returned to the caller
+  TLoadAction = (laHardDisk, laStream, laDiscard, laLoaded);
   TMlLoadDependentLibraryEvent = procedure(const aLibName, aDependentLib: String; var aLoadAction: TLoadAction; var
-      aStream: TStream; var aFreeStream: Boolean) of object;
+      aStream: TStream; var aFreeStream: Boolean; var aLoadedHandle: TLibHandle) of object;
 
 {$IFDEF VER130}
+  EOSError             = class(Exception);
   TValidatePackageProc = function (Module: HMODULE): Boolean;
 {$ENDIF VER130}
 


### PR DESCRIPTION
Update handling of Name and Handle hash trees so the currently loading lib is registered in advance
Updated OnDependencyLoad callback to allow the handler to load the required dependant library and return the handle. Updated tests to correspond.
